### PR TITLE
allow for compiling on case sensitive filesystems

### DIFF
--- a/misc.c
+++ b/misc.c
@@ -22,7 +22,7 @@
 // WIN32 specific
 #if defined(WIN32)
 
-  #include "Windows.h"
+  #include "windows.h"
 
   // forground colours
   #define FG_BLACK      0


### PR DESCRIPTION
Cross-compiling stm8gal on a Linux system for Windows results in a compiler error due to a case mismatch of an include file.