### PR TITLE
fix wrong initialization of 'number of bits' field for POSIX systems

### DIFF
--- a/serial_comm.c
+++ b/serial_comm.c
@@ -691,7 +691,7 @@ void set_port_attribute(HANDLE fpCom, uint32_t baudrate, uint32_t timeout, uint8
     toptions.c_cflag &= ~CSTOPB;    // one stop bit
   else
     toptions.c_cflag |= CSTOPB;     // two stop bit
-  toptions.c_cflag &= ~CSIZE;       // clear data bits entry
+//  toptions.c_cflag &= ~CSIZE;       // clear data bits entry
   
   // disable flow control
   toptions.c_cflag &= ~CRTSCTS;


### PR DESCRIPTION
synchronization failed on Linux. Instead of 0x7f the value 0xff was send. The number of bits was accidentally wiped again (and reset to 5 data bits) right after correctly setting it to 8.