### PR TITLE
Add Intel HEX format export + fixes to SREC export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,5 +57,6 @@ tool_validation.*
 *.wed
 *.cdb
 *.ihx
+*.s19
 /stm8gal.exe
 *_dump.txt

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Supported import formats (option '-w'):
 Supported export formats (option '-r'):
   - print to stdout ('console')
   - Motorola S19 (*.s19)
+  - Intel Hex (*.hex, *.ihx)
   - ASCII table (*.txt) with 'hexAddr  hexValue'
   - Binary (*.bin) without starting address
 

--- a/hexfile.c
+++ b/hexfile.c
@@ -997,11 +997,11 @@ void export_s19(char *filename, uint16_t *imageBuf, uint8_t verbose) {
     ///////
 
     // save data, accound for address width
-    if (addrBlock <= 0xFFFF) {
+    if (addrStop <= 0xFFFF) {
       fprintf(fp, "S1%02X%04X", lenBlock+3, addrBlock);        // 16-bit address: 2B addr + data + 1B chk
       chk = (uint8_t) (lenBlock+3) + (uint8_t) addrBlock + (uint8_t) (addrBlock >> 8);
     }
-    else if (addrBlock <= 0xFFFFFF) {
+    else if (addrStop <= 0xFFFFFF) {
       fprintf(fp, "S2%02X%06X", lenBlock+4, addrBlock);        // 24-bit address: 3B addr + data + 1B chk
       chk = (uint8_t) (lenBlock+4) + (uint8_t) addrBlock + (uint8_t) (addrBlock >> 8) + (uint8_t) (addrBlock >> 16);
     }
@@ -1022,8 +1022,13 @@ void export_s19(char *filename, uint16_t *imageBuf, uint8_t verbose) {
 
   } // loop over address range 
 
-  // attach generic EOF line
-  fprintf(fp, "S903FFFFFE\n");
+  // attach appropriate termination record, according to type of data records used
+  if (addrStop <= 0xFFFF)
+    fprintf(fp, "S9030000FC\n");        // 16-bit addresses
+  else if (addrStop <= 0xFFFFFF)
+    fprintf(fp, "S804000000FB\n");      // 24-bit addresses
+  else
+    fprintf(fp, "S70500000000FA\n");    // 32-bit addresses
 
   // close output file
   fflush(fp);

--- a/hexfile.h
+++ b/hexfile.h
@@ -62,6 +62,9 @@ void  move_image(uint16_t *imageBuf, uint32_t fromStart, uint32_t fromStop, uint
 /// export RAM image to file in Motorola s19 format
 void  export_s19(char *filename, uint16_t *imageBuf, uint8_t verbose);
 
+/// export RAM image to file in Intel HEX format
+void  export_ihx(char *filename, uint16_t *imageBuf, uint8_t verbose);
+
 /// export RAM image to plain text file or print to console
 void  export_txt(char *filename, uint16_t *imageBuf, uint8_t verbose);
 

--- a/main.c
+++ b/main.c
@@ -410,6 +410,7 @@ int main(int argc, char ** argv) {
     printf("Supported export formats:\n");
     printf("  - print to stdout (console)\n");
     printf("  - Motorola S19 (*.s19)\n");
+    printf("  - Intel Hex (*.hex, *.ihx)\n");
     printf("  - ASCII table (*.txt) with 'hexAddr  hexValue'\n");
     printf("  - Binary data (*.bin) without starting address\n");
     printf("\n");
@@ -1018,6 +1019,8 @@ int main(int argc, char ** argv) {
       // export in format depending on file extension 
       if (strstr(outfile, ".s19") != NULL)   // Motorola S-record format
         export_s19(outfile, imageBuf, verbose);
+      else if ((strstr(outfile, ".hex") != NULL) || (strstr(outfile, ".ihx") != NULL))   // Intel HEX-format
+        export_ihx(outfile, imageBuf, verbose);
       else if (strstr(outfile, ".txt") != NULL)   // text table (hexAddr / hexData)
         export_txt(outfile, imageBuf, verbose);
       else if (strstr(outfile, ".bin") != NULL)   // binary format


### PR DESCRIPTION
I have added the capability to export in Intel HEX format. Supports Extended Linear Address (ELA) records where end address is greater than 16-bit value, so as to handle STM8 devices with >32KB flash. (Please note I haven't been able to test with devices with <32KB flash, as I do not own any, so would appreciate if someone else could test that this scenario works without problems too.)

Also did some fixes to the `export_s19()` SREC export function:

- For devices with >32KB flash, it was originally outputting a mixture of S1 and S2 records (16- and 24-bit addresses) - that is, it would change record type on a per-record basis, when record addresses became > 0xFFFF. I am not actually sure whether mixing record types is allowed, but my hex editor's SREC import didn't like it, and probably not a good idea for consistency's sake. Fixed to now use the largest necessary record type for the entire file.

- In light of the above, a fixed S9 terminating record was not appropriate any more, so now the relevant termination record type (S7/S8/S9) is used in accordance to the data record type.

I have tried to keep with existing code formatting and variable naming conventions, so hopefully meets with your approval. :)