### PR TITLE
Makefile: support cross-compiling on unix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 # Project: stm8gal
 
-CC            = gcc
-CFLAGS        = -c -Wall -I./RAM_Routines/write_erase -I./RAM_Routines/verify_CRC32
+ifeq ($(origin CC), default)
+CC = $(CROSS_COMPILE)gcc
+endif
+CFLAGS        += -c -Wall -I./RAM_Routines/write_erase -I./RAM_Routines/verify_CRC32
 #CFLAGS       += -DDEBUG
-LDFLAGS       = -g3 -lm
+LDFLAGS       += -g3 -lm
 SOURCES       = bootloader.c hexfile.c main.c misc.c serial_comm.c spi_Arduino_comm.c verify_CRC32.c
 INCLUDES      = misc.h bootloader.h hexfile.h serial_comm.h spi_spidev_comm.h spi_Arduino_comm.h verify_CRC32.h main.h
 RAMINCLUDES   = \


### PR DESCRIPTION
Support cross-compiling stm8gal on unix-based platforms. This is useful for embedded systems where an stm8 processor can be updated via a serial connection from an arm-based cpu that runs linux.

If the caller sets the CC variable in his environment, we leave CC alone in the Makefile and use the caller's settings. This is the case for cross-compiler toolchains that provide a setup script.

If CC hasn't been set by the caller, we set it in the Makefile and take the cross-compiler prefix into account. Setting CROSS_COMPILE is standard practice for cross-compiler toolchains.

By default, CROSS_COMPILE is empty and CC = gcc. In this case, we compile for the local system.

Keep caller-provided settings for CFLAGS and LDFLAGS, append our settings instead of overwriting.