### PR TITLE
main: hexfile: avoid huge file buffer

### DIFF
--- a/hexfile.c
+++ b/hexfile.c
@@ -73,7 +73,7 @@ char *get_line(char **buf, char *line) {
 
    read file from file to memory buffer. Don't interpret (is done in separate routine)
 */
-void load_file(const char *filename, char *fileBuf, uint64_t *lenFileBuf, uint8_t verbose) {
+void load_file(const char *filename, char **fileBuf, uint64_t *lenFileBuf, uint8_t verbose) {
 
   FILE      *fp;
 
@@ -102,15 +102,11 @@ void load_file(const char *filename, char *fileBuf, uint64_t *lenFileBuf, uint8_
   (*lenFileBuf) = ftell(fp);
   fseek(fp, 0, SEEK_SET);
 
-  // check file size vs. buffer
-  if ((*lenFileBuf) > LENFILEBUF)
-    Error("File %s exceeded buffer size (%ld vs %ld)", (*lenFileBuf), LENFILEBUF);
-
-  // init memory image to zero
-  memset(fileBuf, 0, LENFILEBUF * sizeof(*fileBuf));
+  if (!(*fileBuf = malloc((*lenFileBuf) * sizeof(*fileBuf))))
+      Error("Cannot allocate file buffer");
 
   // read file to buffer
-  fread(fileBuf, (*lenFileBuf), 1, fp);
+  fread(*fileBuf, (*lenFileBuf), 1, fp);
 
   // close file again
   fclose(fp);

--- a/hexfile.h
+++ b/hexfile.h
@@ -17,9 +17,6 @@
 #ifndef _HEXFILE_H_
 #define _HEXFILE_H_
 
-/// buffer size [B] for files
-#define  LENFILEBUF   50*1024*1024
-
 /// buffer size [B] for memory image
 #define  LENIMAGEBUF  50*1024*1024
 
@@ -28,7 +25,7 @@
 char  *get_line(char **buf, char *line);
 
 /// read file into memory buffer
-void  load_file(const char *filename, char *fileBuf, uint64_t *lenFileBuf, uint8_t verbose);
+void  load_file(const char *filename, char **fileBuf, uint64_t *lenFileBuf, uint8_t verbose);
 
 /// convert Motorola s19 format in memory buffer to memory image
 void  convert_s19(char *fileBuf, uint64_t lenFileBuf, uint16_t *imageBuf, uint8_t verbose);

--- a/main.c
+++ b/main.c
@@ -833,10 +833,6 @@ int main(int argc, char ** argv) {
       char      *fileBuf;              // RAM buffer for input file
       uint64_t  lenFile;               // length of file in fileBuf
 
-      // allocate intermediate buffers (>1MByte requires dynamic allocation)
-      if (!(fileBuf = malloc(LENFILEBUF * sizeof(*fileBuf))))
-        Error("Cannot allocate file buffer, try reducing LENFILEBUF");
-
       // get file name
       strncpy(infile, argv[++i], STRLEN-1);
 
@@ -851,7 +847,7 @@ int main(int argc, char ** argv) {
       }
 
       // import file into string buffer (no interpretation, yet)
-      load_file(infile, fileBuf, &lenFile, verbose);
+      load_file(infile, &fileBuf, &lenFile, verbose);
 
       // clear image buffer
       memset(imageBuf, 0, (LENIMAGEBUF + 1) * sizeof(*imageBuf));


### PR DESCRIPTION
The code allocates a buffer of LENFILEBUF bytes (50 Mb) to store a disk file before it's converted and uploaded. This is a problem on embedded systems where RAM is limited.

We can avoid this large buffer simply by allocating the buffer in load_file, not in main. The load_file function reads the file size anyway, it can allocate a buffer that's exactly the size of our file.

Now that we fill the entire buffer with our file, there's no need to initialise it with 0x00 bytes.