### PR TITLE
hexfile: shrink memory image buffer

### DIFF
--- a/hexfile.h
+++ b/hexfile.h
@@ -21,7 +21,7 @@
 #define  LENFILEBUF   50*1024*1024
 
 /// buffer size [B] for memory image
-#define  LENIMAGEBUF  50*1024*1024
+#define  LENIMAGEBUF  5*1024*1024
 
 
 /// read next line from RAM buffer


### PR DESCRIPTION
We're using a 50Mb memory buffer raw data that we're about to upload to the stm8 or that we've just downloaded from the stm8. If stm8gal runs on an embedded system with limited ram, this huge buffer is a problem.

The data in this buffer is transferred 1:1 to/from the stm8. It cannot be larger than the maximum flash size of the stm8, i.e. 256Kb.

Let's reduce the buffer size from 50Mb to 5Mb for now.