### PR TITLE
bootloader: recognize stm8 chips with 64Kb flash

### DIFF
--- a/bootloader.c
+++ b/bootloader.c
@@ -421,6 +421,8 @@ uint8_t bsl_getInfo(HANDLE ptrPort, uint8_t physInterface, uint8_t uartMode, int
     *flashsize = 256;
   else if (bsl_memCheck(ptrPort, physInterface, uartMode, 0x027FFF, SILENT))  // high density (128kB)
     *flashsize = 128;
+  else if (bsl_memCheck(ptrPort, physInterface, uartMode, 0x017FFF, SILENT)) // high density (64kB)
+    *flashsize = 64;
   else if (bsl_memCheck(ptrPort, physInterface, uartMode, 0x00FFFF, SILENT))  // medium density (32kB)
     *flashsize = 32;
   else if (bsl_memCheck(ptrPort, physInterface, uartMode, 0x009FFF, SILENT))  // low density (8kB)


### PR DESCRIPTION
Add a detection for stm8 chips with 64Kb flash, such as the STM8L151R8. Their flash starts at 0x8000, the highest address is 0x17FFF.

ST's documentation refers to such chips as "high density", see e.g. the DS6948 datasheet.