### PR TITLE
memory_image: use memmove if source and destination overlap

### DIFF
--- a/src/memory_image.c
+++ b/src/memory_image.c
@@ -148,7 +148,7 @@ bool MemoryImage_addData(MemoryImage_s* image, const MEMIMAGE_ADDR_T address, co
 
     // shift higher addresses by +1 to free space for new entry
     if (idx < image->numEntries) {
-        memcpy(&(image->memoryEntries[idx+1L]), &(image->memoryEntries[idx]), (image->numEntries - idx) * (size_t) (sizeof(MemoryEntry_s)));
+        memmove(&(image->memoryEntries[idx+1L]), &(image->memoryEntries[idx]), (image->numEntries - idx) * (size_t) (sizeof(MemoryEntry_s)));
     }
     
     // add new entry at correct location


### PR DESCRIPTION
For memcpy, it is required that the source and destination areas must not overlap, see the memcpy(3) manpage.

It seems that memcpy's behaviour for overlapping areas depends on the internal implementation. It's possible that this works ok on some systems.

stm8gal calls memcpy when a new byte has to be inserted into a memory image. All entries with higher addresses have to be moved by one byte to make room for the new byte.

On a single-core arm system with GLIBC 2.36, we saw that this memcpy operation corrupted the memory image:

memcpy from index 124 -> 125

before:
index 124: addr 0x807f
index 125: addr 0x8080
index 126: addr 0x8081
index 127: addr 0x8082
index 128: addr 0x8083
index 129: addr 0x8084
index 130: addr 0x8085
index 131: addr 0x8086

afterwards:
index 124: addr 0x807f
   (this is ok, this byte will be replaced with the new byte that we're about to insert)
index 125: addr 0x807f
index 126: addr 0x8080
index 127: addr 0x8081
index 128: addr 0x8082
index 129: addr 0x8082
   (this byte was corrupted by memcpy)
index 130: addr 0x8084
index 131: addr 0x8085
index 132: addr 0x8086

Fortunately the fix is very simple: We can use memmove, this function is guaranteed to work with overlapping memory areas.